### PR TITLE
feat: add API to run application

### DIFF
--- a/lua/java.lua
+++ b/lua/java.lua
@@ -58,7 +58,7 @@ M.runner.run_app = runner.run_app
 
 M.runner.built_in = {}
 M.runner.built_in.run_app = runner.built_in.run_app
-M.runner.built_in.toogle_logs = runner.built_in.toogle_logs
+M.runner.built_in.toggle_logs = runner.built_in.toggle_logs
 M.runner.built_in.stop_app = runner.built_in.stop_app
 
 function M.__run()

--- a/lua/java.lua
+++ b/lua/java.lua
@@ -56,6 +56,11 @@ M.manipulate = {}
 M.runner = {}
 M.runner.run_app = runner.run_app
 
+M.runner.built_in = {}
+M.runner.built_in.run_app = runner.built_in.run_app
+M.runner.built_in.toogle_logs = runner.built_in.toogle_logs
+M.runner.built_in.stop_app = runner.built_in.stop_app
+
 function M.__run()
 	test.debug_current_method()
 end

--- a/lua/java.lua
+++ b/lua/java.lua
@@ -5,6 +5,7 @@ local setup_wrap = require('java.startup.lspconfig-setup-wrap')
 
 local test = require('java.api.test')
 local dap = require('java.api.dap')
+local runner = require('java.api.runner')
 
 local global_config = require('java.config')
 
@@ -48,6 +49,12 @@ M.test.view_last_report = test.view_last_report
 ----------------------------------------------------------------------
 M.manipulate = {}
 -- M.manipulate.organize_imports = {}
+
+----------------------------------------------------------------------
+--                            Runner APIs                           --
+----------------------------------------------------------------------
+M.runner = {}
+M.runner.run_app = runner.run_app
 
 function M.__run()
 	test.debug_current_method()

--- a/lua/java/api/runner.lua
+++ b/lua/java/api/runner.lua
@@ -1,0 +1,91 @@
+local log = require('java.utils.log')
+local async = require('java-core.utils.async').sync
+local get_error_handler = require('java.handlers.error')
+local jdtls = require('java.utils.jdtls')
+local notify = require('java-core.utils.notify')
+
+local DapSetup = require('java-dap.api.setup')
+
+local M = {}
+local RunnerApi = {}
+
+--- @class RunnerApi
+--- @field client LspClient
+--- @field private dap JavaCoreDap
+function RunnerApi:new(args)
+	local o = {
+		client = args.client,
+	}
+
+	o.dap = DapSetup(args.client)
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+function RunnerApi:get_config()
+	local configs = self.dap:get_dap_config()
+	log.debug('dap configs: ', configs)
+
+	local config_names = {}
+	local config_lookup = {}
+	for _, config in ipairs(configs) do
+		if config.projectName then
+			table.insert(config_names, config.name)
+			config_lookup[config.name] = config
+		end
+	end
+
+	if #config_names == 0 then
+		notify.warn('Dap config not found')
+		return
+	end
+
+	if #config_names == 1 then
+		return config_lookup[config_names[1]]
+	end
+
+	local selected_config = nil
+	vim.ui.select(config_names, {
+		prompt = 'Select the main class (modul -> mainClass)',
+	}, function(choice)
+		selected_config = config_lookup[choice]
+	end)
+	return selected_config
+end
+
+--- @param callback fun(cmd)
+function RunnerApi:run_app(callback)
+	local config = self:get_config()
+	if not config then
+		return
+	end
+
+	config.request = 'launch'
+	local enrich_config = self.dap:enrich_config(config)
+	local class_paths = table.concat(enrich_config.classPaths, ':')
+	local main_class = enrich_config.mainClass
+	local java_exec = enrich_config.javaExec
+
+	local cmd = {
+		java_exec,
+		'-cp',
+		class_paths,
+		main_class,
+	}
+
+	callback(cmd)
+end
+
+--- @param callback fun(cmd)
+function M.run_app(callback)
+	return async(function()
+			return RunnerApi:new(jdtls()):run_app(callback)
+		end)
+		.catch(get_error_handler('failed to run app'))
+		.run()
+end
+
+M.RunnerApi = RunnerApi
+
+return M

--- a/lua/java/api/runner.lua
+++ b/lua/java/api/runner.lua
@@ -6,12 +6,120 @@ local notify = require('java-core.utils.notify')
 
 local DapSetup = require('java-dap.api.setup')
 
-local M = {}
-local RunnerApi = {}
+--- @class BuiltInMainRunner
+--- @field win  number
+--- @field bufnr number
+--- @field job_id number
+--- @field is_open boolean
+local BuiltInMainRunner = {}
+
+function BuiltInMainRunner:_set_up_buffer_autocmd()
+	local group = vim.api.nvim_create_augroup('logger', { clear = true })
+	vim.api.nvim_create_autocmd({ 'BufHidden' }, {
+		group = group,
+		buffer = self.bufnr,
+		callback = function(_)
+			self.is_open = true
+		end,
+	})
+end
+
+function BuiltInMainRunner:new()
+	local o = {
+		is_open = false,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+--- @param clear_buffer boolean
+function BuiltInMainRunner:stop(clear_buffer)
+	if self.job_id ~= nil then
+		vim.fn.jobstop(self.job_id)
+		vim.api.nvim_buf_set_lines(
+			self.bufnr,
+			-2,
+			-1,
+			false,
+			{ 'Process successfully killed.', ' ', ' ' }
+		)
+		self.job_id = nil
+		if clear_buffer then
+			vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, {})
+		end
+	end
+end
+
+function BuiltInMainRunner:_set_up_buffer()
+	vim.cmd('sp | winc J | res 15 | buffer ' .. self.bufnr)
+	self.win = vim.api.nvim_get_current_win()
+	vim.api.nvim_win_set_option(self.win, 'number', false)
+	vim.api.nvim_win_set_option(self.win, 'relativenumber', false)
+	vim.api.nvim_win_set_option(self.win, 'signcolumn', 'no')
+	self:_set_up_buffer_autocmd()
+	self.is_open = false
+end
+
+function BuiltInMainRunner:_on_std(_, data, _)
+	vim.api.nvim_buf_set_lines(self.bufnr, -2, -1, false, data)
+	local current_buf = vim.api.nvim_get_current_buf()
+	vim.api.nvim_buf_call(self.bufnr, function()
+		local mode = vim.api.nvim_get_mode().mode
+		if current_buf ~= self.bufnr or mode ~= 'i' then
+			vim.cmd('normal! G')
+		end
+	end)
+end
+
+--- @param cmd string[]
+function BuiltInMainRunner:run_app(cmd)
+	self:stop(true)
+	if not self.bufnr then
+		self.bufnr = vim.api.nvim_create_buf(false, true)
+		vim.api.nvim_buf_call(self.bufnr, function()
+			self:_set_up_buffer()
+		end)
+	end
+
+	local command = table.concat(cmd, ' ')
+	vim.api.nvim_buf_set_lines(self.bufnr, -2, -1, false, { command, ' ' })
+	self.job_id = vim.fn.jobstart(command, {
+		on_stdout = function(_, data, _)
+			self:_on_std(_, data, _)
+		end,
+		on_stderr = function(_, data, _)
+			self:_on_std(_, data, _)
+		end,
+	})
+end
+
+function BuiltInMainRunner:hide_logs()
+	if self.bufnr then
+		self.is_open = true
+		vim.api.nvim_buf_call(self.bufnr, function()
+			vim.cmd('hide')
+		end)
+	end
+end
+
+function BuiltInMainRunner:toogle_logs()
+	if self.is_open then
+		vim.api.nvim_buf_call(self.bufnr, function()
+			self:_set_up_buffer()
+			vim.cmd('normal! G')
+		end)
+	else
+		self:hide_logs()
+	end
+end
 
 --- @class RunnerApi
 --- @field client LspClient
 --- @field private dap JavaCoreDap
+local RunnerApi = {}
+
 function RunnerApi:new(args)
 	local o = {
 		client = args.client,
@@ -55,7 +163,8 @@ function RunnerApi:get_config()
 end
 
 --- @param callback fun(cmd)
-function RunnerApi:run_app(callback)
+--- @param args string
+function RunnerApi:run_app(callback, args)
 	local config = self:get_config()
 	if not config then
 		return
@@ -69,23 +178,51 @@ function RunnerApi:run_app(callback)
 
 	local cmd = {
 		java_exec,
+		args or '',
 		'-cp',
 		class_paths,
 		main_class,
 	}
-
+	log.debug('run app cmd: ', cmd)
 	callback(cmd)
 end
 
+local M = {
+	built_in = {},
+}
+
 --- @param callback fun(cmd)
-function M.run_app(callback)
+--- @param args string
+function M.run_app(callback, args)
 	return async(function()
-			return RunnerApi:new(jdtls()):run_app(callback)
+			return RunnerApi:new(jdtls()):run_app(callback, args)
 		end)
 		.catch(get_error_handler('failed to run app'))
 		.run()
 end
 
-M.RunnerApi = RunnerApi
+--- @param opts {}
+function M.built_in.run_app(opts)
+	if not M.BuildInRunner then
+		M.BuildInRunner = BuiltInMainRunner:new()
+	end
+	M.run_app(function(cmd)
+		M.BuildInRunner:run_app(cmd)
+	end, opts.args)
+end
 
+function M.built_in.toogle_logs()
+	if M.BuildInRunner then
+		M.BuildInRunner:toogle_logs()
+	end
+end
+
+function M.built_in.stop_app()
+	if M.BuildInRunner then
+		M.BuildInRunner:stop(false)
+	end
+end
+
+M.RunnerApi = RunnerApi
+M.BuiltInMainRunner = BuiltInMainRunner
 return M

--- a/plugin/java.lua
+++ b/plugin/java.lua
@@ -17,7 +17,7 @@ local cmd_map = {
 
 	JavaRunnerRunMain = { java.runner.built_in.run_app , { nargs = '?' } },
 	JavaRunnerStopMain = { java.runner.built_in.stop_app },
-  JavaRunnerToogleLogs = {java.runner.built_in.toogle_logs},
+  JavaRunnerToggleLogs = {java.runner.built_in.toggle_logs},
 
 
 }

--- a/plugin/java.lua
+++ b/plugin/java.lua
@@ -14,6 +14,12 @@ local cmd_map = {
 	JavaTestDebugCurrentMethod = { java.test.debug_current_method },
 
 	JavaTestViewLastReport = { java.test.view_last_report },
+
+	JavaRunnerRunMain = { java.runner.built_in.run_app , { nargs = '?' } },
+	JavaRunnerStopMain = { java.runner.built_in.stop_app },
+  JavaRunnerToogleLogs = {java.runner.built_in.toogle_logs},
+
+
 }
 
 for cmd, details in pairs(cmd_map) do

--- a/tests/java/api/runner_spec.lua
+++ b/tests/java/api/runner_spec.lua
@@ -179,6 +179,246 @@ describe('java-core.api.runner', function()
 		mock.revert(api)
 	end)
 
+	it(
+		'BuiltInMainRunner:_on_stdout when bufnr is equal to current bufnr and mode is "i" (skip scroll)',
+		function()
+			local mock_current_bufnr = 1
+			local vim = mock(vim, true)
+			local api = mock(vim.api, true)
+			local spy_chensend = spy.on(vim.fn, 'chansend')
+
+			api.nvim_get_current_buf.returns(mock_current_bufnr)
+			api.nvim_get_mode.returns({ mode = 'i' })
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.chan = 2
+			built_in_main_runner.bufnr = mock_current_bufnr
+			spy.on(built_in_main_runner, '_scroll_down')
+
+			built_in_main_runner:_on_stdout({ 'data1', 'data2' })
+
+			assert.spy(spy_chensend).was_called_with(2, { 'data1', 'data2' })
+			-- call nvim_create_buf
+			local call_info = api.nvim_buf_call.calls[1]
+			call_info.vals[2]()
+			assert.spy(built_in_main_runner._scroll_down).was_not_called()
+			--
+			mock.revert(vim)
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:_on_stdout when bufnr is not equal to current bufnr and mode is "i" (scroll)',
+		function()
+			local api = mock(vim.api, true)
+			local spy_chensend = spy.on(vim.fn, 'chansend')
+
+			api.nvim_get_current_buf.returns(2)
+			api.nvim_get_mode.returns({ mode = 'i' })
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = 1
+			built_in_main_runner.chan = 2
+			spy.on(built_in_main_runner, '_scroll_down')
+			built_in_main_runner:_on_stdout({ 'data1', 'data2', 'data3' })
+
+			assert.spy(spy_chensend).was_called_with(2, { 'data1', 'data2', 'data3' })
+			local call_info = api.nvim_buf_call.calls[1]
+			assert.equals(call_info.vals[1], 1)
+
+			call_info.vals[2]()
+			assert.spy(built_in_main_runner._scroll_down).was_called()
+
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:_on_stdout when bufnr is equal to current bufnr and mode is not "i" (scroll)',
+		function()
+			local mock_current_bufnr = 1
+			local api = mock(vim.api, true)
+			local spy_chensend = spy.on(vim.fn, 'chansend')
+
+			api.nvim_get_current_buf.returns(mock_current_bufnr)
+			api.nvim_get_mode.returns({ mode = 'n' })
+			api.nvim_buf_line_count.returns(3)
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = mock_current_bufnr
+			built_in_main_runner.chan = 2
+			spy.on(built_in_main_runner, '_scroll_down')
+			built_in_main_runner:_on_stdout({ 'data1', 'data2' })
+
+			assert.spy(spy_chensend).was_called_with(2, { 'data1', 'data2' })
+			local call_info = api.nvim_buf_call.calls[1]
+			assert.equals(call_info.vals[1], 1)
+
+			call_info.vals[2]()
+			assert.spy(built_in_main_runner._scroll_down).was_called()
+
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:_on_exit when bufnr is equal to current bufnr (scroll)',
+		function()
+			local mock_current_bufnr = 1
+			local api = mock(vim.api, true)
+			local spy_chensend = spy.on(vim.fn, 'chansend')
+			local spy_cmd = spy.on(vim, 'cmd')
+
+			api.nvim_get_current_buf.returns(mock_current_bufnr)
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = mock_current_bufnr
+			built_in_main_runner.chan = 2
+			built_in_main_runner:_on_exit(0)
+
+			assert
+				.spy(spy_chensend)
+				.was_called_with(2, '\nProcess finished with exit code 0\n')
+			assert.spy(spy_cmd).was_called_with('stopinsert')
+			assert.equals(built_in_main_runner.job_id, nil)
+
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:_on_exit when bufnr is not equal to current bufnr (skip scroll)',
+		function()
+			local mock_current_bufnr = 1
+			local api = mock(vim.api, true)
+			local spy_chensend = spy.on(vim.fn, 'chansend')
+			local spy_cmd = spy.on(vim, 'cmd')
+
+			api.nvim_get_current_buf.returns(mock_current_bufnr)
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = mock_current_bufnr + 1
+			built_in_main_runner.chan = 2
+			built_in_main_runner:_on_exit(0)
+
+			assert
+				.spy(spy_chensend)
+				.was_called_with(2, '\nProcess finished with exit code 0\n')
+			assert.spy(spy_cmd).was_not_called()
+			assert.equals(built_in_main_runner.job_id, nil)
+
+			mock.revert(api)
+		end
+	)
+
+	it('BuiltInMainRunner:run_app when there is no running job', function()
+		local fn = mock(vim.fn, true)
+		local spy_jobstart = spy.on(fn, 'jobstart')
+		local spy_chansend = spy.on(fn, 'chansend')
+		local spy_stop = spy.on(fn, 'jobstop')
+		local api = mock(vim.api, true)
+
+		api.nvim_create_buf.returns(1)
+		api.nvim_open_term.returns(2)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
+
+		assert
+			.spy(spy_chansend)
+			.was_called_with(2, 'java -cp path1:path2 mainClass')
+		assert.stub(api.nvim_buf_call).was_called()
+		assert.spy(spy_jobstart).was_called()
+		assert.not_nil(built_in_main_runner.job_id)
+
+		local call_info = fn.jobstart.calls[1]
+		assert.equals(call_info.vals[1], 'java -cp path1:path2 mainClass')
+		assert.not_nil(call_info.vals[2].on_exit)
+		assert.not_nil(call_info.vals[2].on_stdout)
+		assert.spy(spy_stop).was_not_called()
+
+		mock.revert(api)
+		mock.revert(fn)
+	end)
+
+	it('BuiltInMainRunner:run_app when there is a running job', function()
+		local fn = mock(vim.fn, true)
+		local spy_chensend = spy.on(fn, 'chansend')
+		local spy_jobstart = spy.on(fn, 'jobstart')
+		local spy_jobwait = spy.on(fn, 'jobwait')
+		local spy_stop = spy.on(fn, 'jobstop')
+		local api = mock(vim.api, true)
+
+		api.nvim_create_buf.returns(1)
+		api.nvim_open_term.returns(2)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.bufnr = 11
+		built_in_main_runner.job_id = 1
+		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
+
+		assert
+			.spy(spy_chensend)
+			.was_called_with(2, 'java -cp path1:path2 mainClass')
+		assert.spy(spy_stop).was_called_with(1)
+		assert.spy(spy_jobstart).was_called()
+		assert.spy(spy_jobwait).was_called_with({ 1 }, 1000)
+
+		mock.revert(api)
+		mock.revert(fn)
+	end)
+
+	it('BuiltInMainRunner:toggle_logs when is_open=true', function()
+		local api = mock(vim.api, true)
+
+		api.nvim_buf_line_count.returns(3)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.is_open = true
+		built_in_main_runner.bufnr = 11
+		spy.on(built_in_main_runner, '_set_up_buffer')
+		spy.on(built_in_main_runner, 'hide_logs')
+
+		built_in_main_runner:toggle_logs()
+
+		local call_info = api.nvim_buf_call.calls[1]
+		assert.equals(call_info.vals[1], 11)
+
+		call_info.vals[2]()
+		assert.spy(built_in_main_runner._set_up_buffer).was_called()
+		assert.spy(built_in_main_runner.hide_logs).was_not_called()
+
+		mock.revert(api)
+	end)
+
+	it('BuiltInMainRunner:toggle_logs when is_open=false', function()
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.is_open = false
+		spy.on(built_in_main_runner, 'hide_logs')
+
+		built_in_main_runner:toggle_logs()
+
+		assert.stub(api.nvim_buf_call).was_not_called()
+		assert.spy(built_in_main_runner.hide_logs).was_called()
+
+		mock.revert(api)
+	end)
+
+	it('BuiltInMainRunner:stop when job_id is nil', function()
+		local fn = mock(vim.fn, true)
+		local spy_jobstop = spy.on(fn, 'jobstop')
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner:stop()
+
+		assert.spy(spy_jobstop).was_not_called()
+
+		mock.revert(fn)
+	end)
+
 	it('BuiltInMainRunner:hide_logs', function()
 		local vim = mock(vim, true)
 		local spy_cmd = spy.on(vim, 'cmd')
@@ -199,191 +439,6 @@ describe('java-core.api.runner', function()
 		mock.revert(api)
 	end)
 
-	it(
-		'BuiltInMainRunner:on_std when bufnr is equal to current bufnr and mode is i (skip scroll)',
-		function()
-			local vim = mock(vim, true)
-			local spy_cmd = spy.on(vim, 'cmd')
-			local api = mock(vim.api, true)
-
-			api.nvim_get_current_buf.returns(1)
-			api.nvim_get_mode.returns({ mode = 'i' })
-
-			local built_in_main_runner = runner.BuiltInMainRunner:new()
-			built_in_main_runner.bufnr = 1
-			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
-
-			assert
-				.stub(api.nvim_buf_set_lines)
-				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
-
-			local call_info = api.nvim_buf_call.calls[1]
-			assert.equals(call_info.vals[1], 1)
-
-			call_info.vals[2]()
-			assert.spy(spy_cmd).was_not_called()
-
-			mock.revert(vim)
-			mock.revert(api)
-		end
-	)
-
-	it(
-		'BuiltInMainRunner:on_std when bufnr is not equal to current bufnr and mode is i (scroll)',
-		function()
-			local vim = mock(vim, true)
-			local spy_cmd = spy.on(vim, 'cmd')
-			local api = mock(vim.api, true)
-
-			api.nvim_get_current_buf.returns(2)
-			api.nvim_get_mode.returns({ mode = 'i' })
-
-			local built_in_main_runner = runner.BuiltInMainRunner:new()
-			built_in_main_runner.bufnr = 1
-			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
-
-			assert
-				.stub(api.nvim_buf_set_lines)
-				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
-			local call_info = api.nvim_buf_call.calls[1]
-			assert.equals(call_info.vals[1], 1)
-
-			call_info.vals[2]()
-			assert.spy(spy_cmd).was_called_with('normal! G')
-
-			mock.revert(vim)
-			mock.revert(api)
-		end
-	)
-
-	it(
-		'BuiltInMainRunner:on_std when bufnr is equal to current bufnr and mode is not i (scroll)',
-		function()
-			local vim = mock(vim, true)
-			local spy_cmd = spy.on(vim, 'cmd')
-			local api = mock(vim.api, true)
-
-			api.nvim_get_current_buf.returns(1)
-			api.nvim_get_mode.returns({ mode = 'n' })
-
-			local built_in_main_runner = runner.BuiltInMainRunner:new()
-			built_in_main_runner.bufnr = 1
-			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
-
-			assert
-				.stub(api.nvim_buf_set_lines)
-				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
-			local call_info = api.nvim_buf_call.calls[1]
-			assert.equals(call_info.vals[1], 1)
-
-			call_info.vals[2]()
-			assert.spy(spy_cmd).was_called_with('normal! G')
-
-			mock.revert(vim)
-			mock.revert(api)
-		end
-	)
-
-	it('BuiltInMainRunner:run_app when there is no running job', function()
-		local fn = mock(vim.fn, true)
-		local spy_jobstart = spy.on(fn, 'jobstart')
-		local spy_stop = spy.on(fn, 'jobstop')
-		local api = mock(vim.api, true)
-
-		api.nvim_create_buf.returns(1)
-
-		local built_in_main_runner = runner.BuiltInMainRunner:new()
-		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
-
-		assert
-			.stub(api.nvim_buf_set_lines)
-			.was_called_with(1, -2, -1, false, { 'java -cp path1:path2 mainClass', ' ' })
-		assert.stub(api.nvim_buf_call).was_called()
-
-		assert.spy(spy_jobstart).was_called()
-		assert.not_nil(built_in_main_runner.job_id)
-		local call_info = fn.jobstart.calls[1]
-		assert.equals(call_info.vals[1], 'java -cp path1:path2 mainClass')
-		assert.not_nil(call_info.vals[2].on_stdout)
-		assert.not_nil(call_info.vals[2].on_stderr)
-
-		assert.spy(spy_stop).was_not_called()
-
-		mock.revert(api)
-		mock.revert(fn)
-	end)
-
-	it('BuiltInMainRunner:run_app when there is a running job', function()
-		local fn = mock(vim.fn, true)
-		local spy_jobstart = spy.on(fn, 'jobstart')
-		local spy_stop = spy.on(fn, 'jobstop')
-		local api = mock(vim.api, true)
-
-		local built_in_main_runner = runner.BuiltInMainRunner:new()
-		built_in_main_runner.bufnr = 11
-		built_in_main_runner.job_id = 1
-		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
-
-		assert
-			.stub(api.nvim_buf_set_lines)
-			.was_called_with(11, -2, -1, false, { 'java -cp path1:path2 mainClass', ' ' })
-		assert.spy(spy_stop).was_called()
-		assert.spy(spy_jobstart).was_called()
-
-		mock.revert(api)
-		mock.revert(fn)
-	end)
-
-	it('BuiltInMainRunner:toogle_logs when is_open=true', function()
-		local api = mock(vim.api, true)
-
-		local built_in_main_runner = runner.BuiltInMainRunner:new()
-		built_in_main_runner.is_open = true
-		built_in_main_runner.bufnr = 11
-		spy.on(built_in_main_runner, '_set_up_buffer')
-		spy.on(built_in_main_runner, 'hide_logs')
-		spy.on(vim, 'cmd')
-
-		built_in_main_runner:toogle_logs()
-
-		local call_info = api.nvim_buf_call.calls[1]
-		assert.equals(call_info.vals[1], 11)
-
-		call_info.vals[2]()
-		assert.spy(built_in_main_runner._set_up_buffer).was_called()
-		assert.spy(built_in_main_runner.hide_logs).was_not_called()
-		assert.spy(vim.cmd).was_called_with('normal! G')
-
-		mock.revert(api)
-	end)
-
-	it('BuiltInMainRunner:toogle_logs when is_open=false', function()
-		local api = mock(vim.api, true)
-
-		local built_in_main_runner = runner.BuiltInMainRunner:new()
-		built_in_main_runner.is_open = false
-		spy.on(built_in_main_runner, 'hide_logs')
-
-		built_in_main_runner:toogle_logs()
-
-		assert.stub(api.nvim_buf_call).was_not_called()
-		assert.spy(built_in_main_runner.hide_logs).was_called()
-
-		mock.revert(api)
-	end)
-
-	it('BuiltInMainRunner:stop when job_id is nil', function()
-		local fn = mock(vim.fn, true)
-		local spy_jobstop = spy.on(fn, 'jobstop')
-
-		local built_in_main_runner = runner.BuiltInMainRunner:new()
-		built_in_main_runner:stop()
-
-		assert.spy(spy_jobstop).was_not_called()
-
-		mock.revert(fn)
-	end)
-
 	it('built_in.run_app', function()
 		local built_in_main_runner_mock = mock(runner.BuiltInMainRunner, true)
 		built_in_main_runner_mock.new.returns(built_in_main_runner_mock)
@@ -402,13 +457,13 @@ describe('java-core.api.runner', function()
 		assert.spy(built_in_main_runner_mock.run_app).was_called()
 	end)
 
-	it('built_in.toogle_logs', function()
+	it('built_in.toggle_logs', function()
 		local built_in_main_runner_mock = mock(runner.BuiltInMainRunner, true)
-		spy.on(built_in_main_runner_mock, 'toogle_logs')
+		spy.on(built_in_main_runner_mock, 'toggle_logs')
 		runner.BuildInRunner = built_in_main_runner_mock
 
-		runner.built_in.toogle_logs()
-		assert.spy(built_in_main_runner_mock.toogle_logs).was_called()
+		runner.built_in.toggle_logs()
+		assert.spy(built_in_main_runner_mock.toggle_logs).was_called()
 
 		runner.BuildInRunner = nil
 	end)

--- a/tests/java/api/runner_spec.lua
+++ b/tests/java/api/runner_spec.lua
@@ -1,0 +1,101 @@
+local spy = require('luassert.spy')
+local mock = require('luassert.mock')
+local notify = require('java-core.utils.notify')
+local DapSetup = require('java-dap.api.setup')
+local mock_client = { jdtls_args = {} }
+local runner = require('java.api.runner')
+
+local RunnerApi = runner.RunnerApi:new({ client = mock_client })
+describe('java-core.api.runner', function()
+	it('RunnerApi:new', function()
+		local mock_dap = DapSetup(mock_client)
+		assert.same(RunnerApi.client, mock_client)
+		assert.same(RunnerApi.dap, mock_dap)
+	end)
+
+	it('RunnerApi:get_config when no config found', function()
+		local dap_mock = mock(DapSetup, true)
+		dap_mock.get_dap_config.returns({})
+
+		local notify_spy = spy.on(notify, 'warn')
+		local config = RunnerApi:get_config()
+
+		assert.equals(config, nil)
+		assert.spy(notify_spy).was_called_with('Dap config not found')
+		mock.revert()
+	end)
+
+	it('RunnerApi:get_config when only one config found', function()
+		local dap_mock = mock(DapSetup, true)
+		dap_mock.get_dap_config.returns({
+			{ name = 'config1', projectName = 'projectName' },
+		})
+
+		local config = RunnerApi:get_config()
+		assert.same(config, { name = 'config1', projectName = 'projectName' })
+		mock.revert()
+	end)
+
+	it('RunnerApi:get_config when multiple config found', function()
+		RunnerApi.dap.get_dap_config = function()
+			return {
+				{ name = 'config1' },
+				{ name = 'config2', projectName = 'project2' },
+
+				{ name = 'config3', projectName = 'project3' },
+			}
+		end
+
+		local ui = mock(vim.ui, true)
+		local mock_select = function(main_class_choices, opts, callback)
+			assert.same(main_class_choices, { 'config2', 'config3' })
+			assert.same(opts, {
+				prompt = 'Select the main class (modul -> mainClass)',
+			})
+			callback('config2', 2)
+		end
+
+		ui.select = mock_select
+		local config = RunnerApi:get_config()
+
+		assert.same({ name = 'config2', projectName = 'project2' }, config)
+		mock.revert(ui)
+	end)
+
+	it('RUnnerApi:run_app when no config found', function()
+		RunnerApi.get_config = function()
+			return nil
+		end
+
+		local callback_mock = function(_) end
+		local callback_spy = spy.new(callback_mock)
+
+		RunnerApi:run_app(callback_spy)
+		assert.spy(callback_spy).was_not_called()
+	end)
+
+	it('RUnnerApi:run_app', function()
+		RunnerApi.get_config = function()
+			return { name = 'config1' }
+		end
+
+		RunnerApi.dap.enrich_config = function()
+			return {
+				classPaths = { 'path1', 'path2' },
+				mainClass = 'mainClass',
+				javaExec = 'javaExec',
+			}
+		end
+
+		local callback_mock = function(_) end
+		local callback_spy = spy.new(callback_mock)
+
+		RunnerApi:run_app(callback_spy)
+		assert.spy(callback_spy).was_called_with({
+			'javaExec',
+			'-cp',
+			'path1:path2',
+			'mainClass',
+		})
+	end)
+end)

--- a/tests/java/api/runner_spec.lua
+++ b/tests/java/api/runner_spec.lua
@@ -6,6 +6,7 @@ local mock_client = { jdtls_args = {} }
 local runner = require('java.api.runner')
 
 local RunnerApi = runner.RunnerApi:new({ client = mock_client })
+
 describe('java-core.api.runner', function()
 	it('RunnerApi:new', function()
 		local mock_dap = DapSetup(mock_client)
@@ -62,7 +63,7 @@ describe('java-core.api.runner', function()
 		mock.revert(ui)
 	end)
 
-	it('RUnnerApi:run_app when no config found', function()
+	it('RunnerApi:run_app when no config found', function()
 		RunnerApi.get_config = function()
 			return nil
 		end
@@ -74,7 +75,7 @@ describe('java-core.api.runner', function()
 		assert.spy(callback_spy).was_not_called()
 	end)
 
-	it('RUnnerApi:run_app', function()
+	it('RUnnerApi:run_app without args', function()
 		RunnerApi.get_config = function()
 			return { name = 'config1' }
 		end
@@ -87,15 +88,339 @@ describe('java-core.api.runner', function()
 			}
 		end
 
-		local callback_mock = function(_) end
+		local callback_mock = function(_, _) end
 		local callback_spy = spy.new(callback_mock)
 
 		RunnerApi:run_app(callback_spy)
 		assert.spy(callback_spy).was_called_with({
 			'javaExec',
+			'',
 			'-cp',
 			'path1:path2',
 			'mainClass',
 		})
+	end)
+
+	it('RUnnerApi:run_app with args', function()
+		RunnerApi.get_config = function()
+			return { name = 'config1' }
+		end
+
+		RunnerApi.dap.enrich_config = function()
+			return {
+				classPaths = { 'path1', 'path2' },
+				mainClass = 'mainClass',
+				javaExec = 'javaExec',
+			}
+		end
+
+		local callback_mock = function(_, _) end
+		local callback_spy = spy.new(callback_mock)
+
+		RunnerApi:run_app(callback_spy, 'args')
+		assert.spy(callback_spy).was_called_with({
+			'javaExec',
+			'args',
+			'-cp',
+			'path1:path2',
+			'mainClass',
+		})
+	end)
+
+	it('BuildInRunner:new', function()
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		assert.equals(built_in_main_runner.is_open, false)
+	end)
+
+	it('BuildInRunner:_set_up_buffer', function()
+		local vim = mock(vim, true)
+		local spy_cmd = spy.on(vim, 'cmd')
+
+		local api = mock(vim.api, true)
+		api.nvim_get_current_win.returns(1)
+
+		local spy_nvim_win_set_option = spy.on(api, 'nvim_win_set_option')
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.bufnr = 1
+		built_in_main_runner.is_open = true
+		spy.on(built_in_main_runner, '_set_up_buffer_autocmd')
+		built_in_main_runner:_set_up_buffer()
+
+		assert.equals(built_in_main_runner.is_open, false)
+		assert.spy(spy_cmd).was_called_with('sp | winc J | res 15 | buffer 1')
+
+		assert.spy(spy_nvim_win_set_option).was_called_with(1, 'number', false)
+		assert
+			.spy(spy_nvim_win_set_option)
+			.was_called_with(1, 'relativenumber', false)
+		assert.spy(spy_nvim_win_set_option).was_called_with(1, 'signcolumn', 'no')
+		assert.spy(built_in_main_runner._set_up_buffer_autocmd).was_called()
+
+		mock.revert(vim)
+		mock.revert(api)
+	end)
+
+	it('BuildInRunner:_set_up_buffer_autocmd', function()
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.bufnr = 1
+		built_in_main_runner.is_open = false
+		built_in_main_runner:_set_up_buffer_autocmd()
+
+		local call_info = api.nvim_create_autocmd.calls[1]
+		assert.same(call_info.vals[1], { 'BufHidden' })
+		assert.equals(call_info.vals[2].buffer, 1)
+
+		call_info.vals[2].callback()
+		assert.is_true(built_in_main_runner.is_open)
+
+		mock.revert(api)
+	end)
+
+	it('BuiltInMainRunner:hide_logs', function()
+		local vim = mock(vim, true)
+		local spy_cmd = spy.on(vim, 'cmd')
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.bufnr = 1
+		built_in_main_runner:hide_logs()
+
+		local call_info = api.nvim_buf_call.calls[1]
+		assert.equals(call_info.vals[1], 1)
+		assert.is_function(call_info.vals[2])
+
+		call_info.vals[2]()
+		assert.spy(spy_cmd).was_called_with('hide')
+
+		mock.revert(vim)
+		mock.revert(api)
+	end)
+
+	it(
+		'BuiltInMainRunner:on_std when bufnr is equal to current bufnr and mode is i (skip scroll)',
+		function()
+			local vim = mock(vim, true)
+			local spy_cmd = spy.on(vim, 'cmd')
+			local api = mock(vim.api, true)
+
+			api.nvim_get_current_buf.returns(1)
+			api.nvim_get_mode.returns({ mode = 'i' })
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = 1
+			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
+
+			assert
+				.stub(api.nvim_buf_set_lines)
+				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
+
+			local call_info = api.nvim_buf_call.calls[1]
+			assert.equals(call_info.vals[1], 1)
+
+			call_info.vals[2]()
+			assert.spy(spy_cmd).was_not_called()
+
+			mock.revert(vim)
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:on_std when bufnr is not equal to current bufnr and mode is i (scroll)',
+		function()
+			local vim = mock(vim, true)
+			local spy_cmd = spy.on(vim, 'cmd')
+			local api = mock(vim.api, true)
+
+			api.nvim_get_current_buf.returns(2)
+			api.nvim_get_mode.returns({ mode = 'i' })
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = 1
+			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
+
+			assert
+				.stub(api.nvim_buf_set_lines)
+				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
+			local call_info = api.nvim_buf_call.calls[1]
+			assert.equals(call_info.vals[1], 1)
+
+			call_info.vals[2]()
+			assert.spy(spy_cmd).was_called_with('normal! G')
+
+			mock.revert(vim)
+			mock.revert(api)
+		end
+	)
+
+	it(
+		'BuiltInMainRunner:on_std when bufnr is equal to current bufnr and mode is not i (scroll)',
+		function()
+			local vim = mock(vim, true)
+			local spy_cmd = spy.on(vim, 'cmd')
+			local api = mock(vim.api, true)
+
+			api.nvim_get_current_buf.returns(1)
+			api.nvim_get_mode.returns({ mode = 'n' })
+
+			local built_in_main_runner = runner.BuiltInMainRunner:new()
+			built_in_main_runner.bufnr = 1
+			built_in_main_runner:_on_std(nil, { 'data1', 'data2' }, nil)
+
+			assert
+				.stub(api.nvim_buf_set_lines)
+				.was_called_with(1, -2, -1, false, { 'data1', 'data2' })
+			local call_info = api.nvim_buf_call.calls[1]
+			assert.equals(call_info.vals[1], 1)
+
+			call_info.vals[2]()
+			assert.spy(spy_cmd).was_called_with('normal! G')
+
+			mock.revert(vim)
+			mock.revert(api)
+		end
+	)
+
+	it('BuiltInMainRunner:run_app when there is no running job', function()
+		local fn = mock(vim.fn, true)
+		local spy_jobstart = spy.on(fn, 'jobstart')
+		local spy_stop = spy.on(fn, 'jobstop')
+		local api = mock(vim.api, true)
+
+		api.nvim_create_buf.returns(1)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
+
+		assert
+			.stub(api.nvim_buf_set_lines)
+			.was_called_with(1, -2, -1, false, { 'java -cp path1:path2 mainClass', ' ' })
+		assert.stub(api.nvim_buf_call).was_called()
+
+		assert.spy(spy_jobstart).was_called()
+		assert.not_nil(built_in_main_runner.job_id)
+		local call_info = fn.jobstart.calls[1]
+		assert.equals(call_info.vals[1], 'java -cp path1:path2 mainClass')
+		assert.not_nil(call_info.vals[2].on_stdout)
+		assert.not_nil(call_info.vals[2].on_stderr)
+
+		assert.spy(spy_stop).was_not_called()
+
+		mock.revert(api)
+		mock.revert(fn)
+	end)
+
+	it('BuiltInMainRunner:run_app when there is a running job', function()
+		local fn = mock(vim.fn, true)
+		local spy_jobstart = spy.on(fn, 'jobstart')
+		local spy_stop = spy.on(fn, 'jobstop')
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.bufnr = 11
+		built_in_main_runner.job_id = 1
+		built_in_main_runner:run_app({ 'java', '-cp', 'path1:path2', 'mainClass' })
+
+		assert
+			.stub(api.nvim_buf_set_lines)
+			.was_called_with(11, -2, -1, false, { 'java -cp path1:path2 mainClass', ' ' })
+		assert.spy(spy_stop).was_called()
+		assert.spy(spy_jobstart).was_called()
+
+		mock.revert(api)
+		mock.revert(fn)
+	end)
+
+	it('BuiltInMainRunner:toogle_logs when is_open=true', function()
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.is_open = true
+		built_in_main_runner.bufnr = 11
+		spy.on(built_in_main_runner, '_set_up_buffer')
+		spy.on(built_in_main_runner, 'hide_logs')
+		spy.on(vim, 'cmd')
+
+		built_in_main_runner:toogle_logs()
+
+		local call_info = api.nvim_buf_call.calls[1]
+		assert.equals(call_info.vals[1], 11)
+
+		call_info.vals[2]()
+		assert.spy(built_in_main_runner._set_up_buffer).was_called()
+		assert.spy(built_in_main_runner.hide_logs).was_not_called()
+		assert.spy(vim.cmd).was_called_with('normal! G')
+
+		mock.revert(api)
+	end)
+
+	it('BuiltInMainRunner:toogle_logs when is_open=false', function()
+		local api = mock(vim.api, true)
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner.is_open = false
+		spy.on(built_in_main_runner, 'hide_logs')
+
+		built_in_main_runner:toogle_logs()
+
+		assert.stub(api.nvim_buf_call).was_not_called()
+		assert.spy(built_in_main_runner.hide_logs).was_called()
+
+		mock.revert(api)
+	end)
+
+	it('BuiltInMainRunner:stop when job_id is nil', function()
+		local fn = mock(vim.fn, true)
+		local spy_jobstop = spy.on(fn, 'jobstop')
+
+		local built_in_main_runner = runner.BuiltInMainRunner:new()
+		built_in_main_runner:stop()
+
+		assert.spy(spy_jobstop).was_not_called()
+
+		mock.revert(fn)
+	end)
+
+	it('built_in.run_app', function()
+		local built_in_main_runner_mock = mock(runner.BuiltInMainRunner, true)
+		built_in_main_runner_mock.new.returns(built_in_main_runner_mock)
+		spy.on(built_in_main_runner_mock, 'run_app')
+		spy.on(built_in_main_runner_mock, 'new')
+
+		runner.run_app = function(callback, args)
+			assert.equals(args, 'args')
+			callback()
+		end
+
+		runner.built_in.run_app({ args = 'args' })
+
+		assert.not_nil(runner.BuiltInMainRunner)
+		assert.spy(built_in_main_runner_mock.new).was_called()
+		assert.spy(built_in_main_runner_mock.run_app).was_called()
+	end)
+
+	it('built_in.toogle_logs', function()
+		local built_in_main_runner_mock = mock(runner.BuiltInMainRunner, true)
+		spy.on(built_in_main_runner_mock, 'toogle_logs')
+		runner.BuildInRunner = built_in_main_runner_mock
+
+		runner.built_in.toogle_logs()
+		assert.spy(built_in_main_runner_mock.toogle_logs).was_called()
+
+		runner.BuildInRunner = nil
+	end)
+
+	it('built_in.stop_app', function()
+		local built_in_main_runner_mock = mock(runner.BuiltInMainRunner, true)
+		spy.on(built_in_main_runner_mock, 'stop')
+
+		runner.BuildInRunner = built_in_main_runner_mock
+
+		runner.built_in.stop_app()
+		assert.spy(built_in_main_runner_mock.stop).was_called()
+		runner.BuildInRunner = nil
 	end)
 end)

--- a/tests/java/java_spec.lua
+++ b/tests/java/java_spec.lua
@@ -1,7 +1,18 @@
 local plugin = require('java')
+local mock = require('luassert.mock')
 
 describe('setup', function()
 	it('setup function', function()
 		assert('setup function is available', plugin.setup)
+	end)
+
+	describe('check runner function available:', function()
+		local mock_runner = mock(plugin.runner, true)
+
+		it('run_app', function()
+			mock_runner.run_app.returns({})
+
+			assert.same(plugin.runner.run_app(), {})
+		end)
 	end)
 end)


### PR DESCRIPTION
- Create a separate API to run applications.
-  example (with toogleterm):  
    ```lua 

    local runner = require('java').runner
    local Terminal = require('toggleterm.terminal').Terminal
    local CustomRunner = {}
    function CustomRunner.stop()
	    if CustomRunner.term then
		    CustomRunner.term:shutdown()
		    CustomRunner.term = nil
	    end
    end

    function CustomRunner.open_toogle_term(cmd)
	    local current_win = vim.api.nvim_get_current_win()
	    CustomRunner.term = Terminal:new({
		    cmd = table.concat(cmd, ' '),
		    hidden = true,
		    direction = 'horizontal',
		    close_on_exit = false,
		    float_opts = {},
		    on_open = function(_)
			    vim.api.nvim_set_current_win(current_win)
			    vim.cmd('stopinsert')
		    end,
	    })
	    CustomRunner.term:toggle()
    end
    
    
    vim.api.nvim_create_user_command('Run', function()
	    CustomRunner.stop()
	    runner.run_app(CustomRunner.open_toogle_term)
    end, {})
    
    vim.api.nvim_create_user_command('Stop', function()
	    CustomRunner.stop()
    end, {}) 
