### PR TITLE
fix: java-debug fails due to unavailablity of v0.52.0

### DIFF
--- a/lua/java/startup/mason-dep.lua
+++ b/lua/java/startup/mason-dep.lua
@@ -46,7 +46,7 @@ function M.get_pkg_list(config)
 	local dependecies = {
 		{ name = 'jdtls', version = 'v1.30.1' },
 		{ name = 'java-test', version = '0.40.1' },
-		{ name = 'java-debug-adapter', version = '0.52.0' },
+		{ name = 'java-debug-adapter', version = '0.55.0' },
 	}
 
 	if config.jdk.auto_install then


### PR DESCRIPTION
- main registry has updated the java-debug adapter version to 0.55.0
- however, mason still cannot handle different versions eventhough openvsx got them in the reg