### PR TITLE
updated JDTLS version from 1.31 to 1.33

### DIFF
--- a/lua/java/startup/mason-dep.lua
+++ b/lua/java/startup/mason-dep.lua
@@ -44,7 +44,7 @@ end
 
 function M.get_pkg_list(config)
 	local dependecies = {
-		{ name = 'jdtls', version = 'v1.31.0' },
+		{ name = 'jdtls', version = 'v1.33.0' },
 		{ name = 'java-test', version = '0.40.1' },
 		{ name = 'java-debug-adapter', version = '0.55.0' },
 	}


### PR DESCRIPTION
![2024-02-26_16-27](https://github.com/nvim-java/nvim-java/assets/41318271/6e2d4491-bd8c-4180-9704-4c0715eca955)
![2024-02-26_16-28](https://github.com/nvim-java/nvim-java/assets/41318271/92652c31-03d3-4084-9673-953ac182a475)


https://download.eclipse.org/jdtls/milestones/1.31.0/jdt-language-server-1.31.0-202402151717.tar.gz -> 404
https://download.eclipse.org/jdtls/milestones/1.33.0/jdt-language-server-1.33.0-202402151717.tar.gz -> 200