### PR TITLE
Remove Runner clear_env

### DIFF
--- a/lua/java/api/runner.lua
+++ b/lua/java/api/runner.lua
@@ -64,7 +64,6 @@ function BuiltInMainRunner:run_app(cmd)
 	vim.fn.chansend(self.chan, command)
 	self.job_id = vim.fn.jobstart(command, {
 		pty = true,
-		clear_env = true,
 		on_stdout = function(_, data)
 			self:_on_stdout(data)
 		end,


### PR DESCRIPTION
This allows for stuff like AWT to access the DISPLAY environment variable.