### PR TITLE
fix: runner cmd #241

### DIFF
--- a/lua/java/runner/run.lua
+++ b/lua/java/runner/run.lua
@@ -7,7 +7,6 @@ local notify = require('java-core.utils.notify')
 ---@field buffer number
 ---@field is_running boolean
 ---@field is_manually_stoped boolean
----@field private cmd string
 ---@field private term_chan_id number
 ---@field private job_chan_id number | nil
 ---@field private is_failure boolean
@@ -15,10 +14,9 @@ local Run = class()
 
 ---@param dap_config java-dap.DapLauncherConfig
 ---@param cmd string[]
-function Run:_init(dap_config, cmd)
+function Run:_init(dap_config)
 	self.name = dap_config.name
 	self.main_class = dap_config.mainClass
-	self.cmd = table.concat(cmd, ' ')
 	self.buffer = vim.api.nvim_create_buf(false, true)
 	self.term_chan_id = vim.api.nvim_open_term(self.buffer, {
 		on_input = function(_, _, _, data)
@@ -27,11 +25,13 @@ function Run:_init(dap_config, cmd)
 	})
 end
 
-function Run:start()
+---@param cmd string[]
+function Run:start(cmd)
+	local merged_cmd = table.concat(cmd, ' ')
 	self.is_running = true
-	self:send_term(self.cmd)
+	self:send_term(merged_cmd)
 
-	self.job_chan_id = vim.fn.jobstart(self.cmd, {
+	self.job_chan_id = vim.fn.jobstart(merged_cmd, {
 		pty = true,
 		on_stdout = function(_, data)
 			self:send_term(data)

--- a/lua/java/runner/runner.lua
+++ b/lua/java/runner/runner.lua
@@ -41,7 +41,7 @@ function Runner:start_run(args)
 	self.curr_run = run
 	self.logger:set_buffer(run.buffer)
 
-	run:start()
+	run:start(cmd)
 end
 
 ---Stops the user selected run


### PR DESCRIPTION
The `Run` class always uses the command passed during the initialization, so the profile config changes don't apply.