### PR TITLE
fix(log): changed default logging path

### DIFF
--- a/lua/java/utils/log.lua
+++ b/lua/java/utils/log.lua
@@ -51,7 +51,7 @@ log.new = function(config, standalone)
 
 	local outfile = string.format(
 		'%s/%s.log',
-		vim.api.nvim_call_function('stdpath', { 'data' }),
+		vim.api.nvim_call_function('stdpath', { 'state' }),
 		config.plugin
 	)
 


### PR DESCRIPTION
 from XDG_DATA_HOME to XDG_STATE_HOME

see https://neovim.io/doc/user/starting.html#_standard-paths