### PR TITLE
🐛fix(`mason v2.0`): Compatibility added

### DIFF
--- a/lua/java/utils/mason.lua
+++ b/lua/java/utils/mason.lua
@@ -8,12 +8,14 @@ local M = {}
 function M.is_available(package_name, package_version)
 	-- guard clause
 	local has_pkg = mason_reg.has_package(package_name)
-	if not has_pkg then return false end
+	if not has_pkg then
+		return false
+	end
 
 	-- check
 	local pkg = mason_reg.get_package(package_name)
 	local version = pkg:get_installed_version()
-  local has_version = version == package_version
+	local has_version = version == package_version
 
 	return has_version
 end
@@ -22,7 +24,9 @@ function M.is_installed(package_name, package_version)
 	-- guard clause
 	local pkg = mason_reg.get_package(package_name)
 	local is_installed = pkg:is_installed()
-	if not is_installed then return false end
+	if not is_installed then
+		return false
+	end
 
 	-- check
 	local installed_version = pkg:get_installed_version()

--- a/lua/java/utils/mason.lua
+++ b/lua/java/utils/mason.lua
@@ -6,42 +6,29 @@ local await = async.wait_handle_ok
 local M = {}
 
 function M.is_available(package_name, package_version)
+	-- guard clause
 	local has_pkg = mason_reg.has_package(package_name)
+	if not has_pkg then return false end
 
-	if not has_pkg then
-		return false
-	end
-
-	local has_version = false
-
+	-- check
 	local pkg = mason_reg.get_package(package_name)
-	pkg:get_installed_version(function(success, version)
-		if success and version == package_version then
-			has_version = true
-		end
-	end)
+	local version = pkg:get_installed_version()
+  local has_version = version == package_version
 
 	return has_version
 end
 
 function M.is_installed(package_name, package_version)
+	-- guard clause
 	local pkg = mason_reg.get_package(package_name)
 	local is_installed = pkg:is_installed()
+	if not is_installed then return false end
 
-	if not is_installed then
-		return false
-	end
+	-- check
+	local installed_version = pkg:get_installed_version()
+	is_installed = installed_version == package_version
 
-	local installed_version
-	pkg:get_installed_version(function(ok, version)
-		if not ok then
-			return
-		end
-
-		installed_version = version
-	end)
-
-	return installed_version == package_version
+	return is_installed
 end
 
 function M.is_outdated(packages)


### PR DESCRIPTION
This little PR:

* Adds compatibility with Mason 2.0.
* Drops compatibility with mason 1.0