### PR TITLE
fix: mason registry verification fails

### DIFF
--- a/lua/java.lua
+++ b/lua/java.lua
@@ -28,6 +28,8 @@ function M.setup(custom_config)
 		{ pattern = 'JavaSetup', data = { config = config } }
 	)
 
+	mason_dep.add_custom_registries(config.mason.registries)
+
 	if not startup_check() then
 		return
 	end

--- a/lua/java/startup/mason-dep.lua
+++ b/lua/java/startup/mason-dep.lua
@@ -16,9 +16,8 @@ local M = {}
 function M.add_custom_registries(registries)
 	local mason_default_config = require('mason.settings').current
 
-	local new_registries = list_util
-		:new(registries)
-		:concat(mason_default_config.registries)
+	local new_registries =
+		list_util:new(registries):concat(mason_default_config.registries)
 
 	require('mason').setup({
 		registries = new_registries,

--- a/lua/java/startup/mason-dep.lua
+++ b/lua/java/startup/mason-dep.lua
@@ -11,18 +11,23 @@ local List = require('java-core.utils.list')
 
 local M = {}
 
----Install mason package dependencies for nvim-java
----@param config java.Config
-function M.install(config)
+---Add custom registries to mason
+---@param registries java.Config
+function M.add_custom_registries(registries)
 	local mason_default_config = require('mason.settings').current
 
-	local registries = list_util
-		:new(config.mason.registries)
+	local new_registries = list_util
+		:new(registries)
 		:concat(mason_default_config.registries)
 
 	require('mason').setup({
-		registries = registries,
+		registries = new_registries,
 	})
+end
+
+---Install mason package dependencies for nvim-java
+---@param config java.Config
+function M.install(config)
 	local packages = M.get_pkg_list(config)
 	local is_outdated = mason_util.is_outdated(packages)
 


### PR DESCRIPTION
TLDR;

What this PR does is:
1. In module `java.startup.mason-dep`: extracts the code responsible for adding custom registries to Mason from `install` into a separate function `add_custom_registries`.

2. In module `java`: calls `mason-dep.add_custom_registries` prior to `startup_check` in `setup`
---
Longer explanation:

Pt. 1 is necessary because `startup_check` needs to be called before `mason-dep.install` in `java.setup` but also `mason-dep.install` was adding the registries, so the verification was always going to fail. It allows for `mason-dep.add_custom_registries` to be called independently.

Pt. 2 is necessary because custom registries need to be added before the invalid registry verification for it to succeed.

fixes #403 