### PR TITLE
fix: java-debug-adapter doean't install

### DIFF
--- a/lua/java/config.lua
+++ b/lua/java/config.lua
@@ -40,7 +40,7 @@ local config = {
 	-- load java debugger plugins
 	java_debug_adapter = {
 		enable = true,
-		version = '0.58.1',
+		version = '0.58.2',
 	},
 
 	spring_boot_tools = {


### PR DESCRIPTION
Bumps the java-dbug-adapter version to 0.58.2 in the default config to conform to the current package definition from Mason repository so that Mason can find the expected file inside the archive.

fixes #406 