### PR TITLE
New disable_automatic_update flag for Mason packages

### DIFF
--- a/lua/java/config.lua
+++ b/lua/java/config.lua
@@ -8,7 +8,7 @@
 ---@field jdk { auto_install: boolean, version: string }
 ---@field notifications { dap: boolean }
 ---@field verification { invalid_order: boolean, duplicate_setup_calls: boolean, invalid_mason_registry: boolean }
----@field mason { registries: string[] }
+---@field mason { disable_automatic_update?:boolean, registries: string[] }
 local config = {
 	--  list of file that exists in root of the project
 	root_markers = {

--- a/lua/java/startup/mason-dep.lua
+++ b/lua/java/startup/mason-dep.lua
@@ -46,7 +46,7 @@ function M.install(config)
 	local packages = M.get_pkg_list(config)
 	local is_outdated = mason_util.is_outdated(packages)
 
-	if is_outdated then
+	if (not config.mason.disable_automatic_update) and is_outdated then
 		sync(function()
 				M.refresh_and_install(packages)
 			end)


### PR DESCRIPTION
With this pull request, there is a new optional config value that allows the user to disable automatic Mason updates (preventing Mason UI from popping up even if there are no updates)
```
{
  mason: {
    disable_automatic_update: true
  }
}
```
If omitted, the behaviour remains the same as before this change.

Solves #416 