### PR TITLE
Refactor JDTLS settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,16 +284,14 @@ Use `vim.lsp.config()` to override the default JDTLS settings:
 
 ```lua
 vim.lsp.config('jdtls', {
-  default_config = {
-    settings = {
-      java = {
-        configuration = {
-          runtimes = {
-            {
-              name = "JavaSE-21",
-              path = "/opt/jdk-21",
-              default = true,
-            }
+  settings = {
+    java = {
+      configuration = {
+        runtimes = {
+          {
+            name = "JavaSE-21",
+            path = "/opt/jdk-21",
+            default = true,
           }
         }
       }


### PR DESCRIPTION
The default_config section in JDTLS settings makes it so nvim-java can't find the list of JDKs.