### PR TITLE
Fix exit code message formatting in Run:on_job_exit

### DIFF
--- a/lua/java-runner/run.lua
+++ b/lua/java-runner/run.lua
@@ -72,7 +72,7 @@ end
 ---Runs when the current job exists
 ---@param exit_code number
 function Run:on_job_exit(exit_code)
-	local message = string.format('Process finished with exit code::%s', exit_code)
+	local message = string.format('Process finished with exit code::%s\n', exit_code)
 	self:send_term(message)
 
 	self.is_running = false


### PR DESCRIPTION
Adding a new line after the exit code improves the readability of the log.

Before:
<img width="1917" height="115" alt="Screenshot from 2025-12-10 10-20-49" src="https://github.com/user-attachments/assets/c6eef2d9-dbac-4559-ab72-8af5c90ca935" />

After:
<img width="1921" height="125" alt="Screenshot from 2025-12-10 10-30-55" src="https://github.com/user-attachments/assets/e70e559e-f0a5-48ef-a172-32dec7813004" />
