### PR TITLE
fix(runner): use argfile for classpath to avoid Windows cmd length limit

### DIFF
--- a/lua/java-core/utils/path.lua
+++ b/lua/java-core/utils/path.lua
@@ -2,8 +2,10 @@ local M = {}
 
 if vim.fn.has('win32') == 1 or vim.fn.has('win32unix') == 1 then
 	M.path_separator = '\\'
+	M.classpath_seperator = ';'
 else
 	M.path_separator = '/'
+	M.classpath_seperator = ':'
 end
 
 ---Join a given list of paths to one path


### PR DESCRIPTION
Fixes https://github.com/nvim-java/nvim-java/issues/465
argFile is only used when using Windows and the would be too long.
I also change the classpath seperator to be conditional as Windows is using ';'