### PR TITLE
fix(refactor): use method-call syntax for Action:rename

### DIFF
--- a/lua/java-refactor/client-command-handlers.lua
+++ b/lua/java-refactor/client-command-handlers.lua
@@ -18,7 +18,7 @@ local M = {
 	---@param params java-refactor.RenameAction[]
 	[ClientCommand.RENAME_COMMAND] = function(params)
 		run('Failed to rename the symbol', function(action)
-			action.rename(params)
+			action:rename(params)
 		end)
 	end,
 


### PR DESCRIPTION
## Summary

`lua/java-refactor/client-command-handlers.lua:21` calls
`action.rename(params)` with a dot. Since `Action:rename` is defined
with `self`, the dot-call passes `params` as `self` and leaves the
actual `params` argument as `nil`, which makes `action.lua:28` error
with:

```
Failed to rename the symbol
.../java-refactor/action.lua:28: bad argument #1 to 'ipairs' (table expected, got nil)
```

Every other handler in this file already uses `:` when calling into
`Action:*` methods (`generate_constructor`, `generate_to_string`,
`apply_refactoring_command`, etc.). This brings `RENAME_COMMAND` in
line with them.

The patch is a one-character change: `.` → `:`.

## Reproduction

1. Open a Java file with jdtls attached.
2. Select a string literal (or any expression) and trigger the refactoring
   that produces a follow-up rename — e.g. "Extract to constant"
   (`textDocument/codeAction` → `refactor.extract.constant`).
3. jdtls applies the edit, then sends `RENAME_COMMAND` back so the new
   symbol can be renamed inline.
4. The handler fails before the rename UI opens, with the error above.

After this fix, the rename UI opens on the newly extracted constant as
expected.

## Test plan

- [x] Hot-applied the same one-character change to a local install
  (`~/.local/share/nvim/lazy/nvim-java/lua/java-refactor/client-command-handlers.lua:21`),
  restarted nvim, and confirmed "Extract to constant" → inline rename
  works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)