### PR TITLE
fix(dap): skip enrich_config for attach mode

### DIFF
--- a/lua/java-dap/setup.lua
+++ b/lua/java-dap/setup.lua
@@ -41,6 +41,14 @@ end
 function Setup:enrich_config(config)
 	config = vim.deepcopy(config)
 
+	-- Attach configs don't need enriching — the JVM is already running and
+	-- chose its own main class, classpath, and java executable. Without this
+	-- short-circuit, the `assert(main, ...)` below fires because attach
+	-- configs (correctly) have no mainClass.
+	if config.request == 'attach' then
+		return config
+	end
+
 	-- skip enriching if already enriched
 	if config.mainClass and config.projectName and config.modulePaths and config.classPaths and config.javaExec then
 		return config


### PR DESCRIPTION
## Summary

`Setup:enrich_config` (`lua/java-dap/setup.lua:41`) asserts that
`mainClass` is present, but attach configs don't have one and don't
need one — the JVM is already running and chose its own main class,
classpath, and java executable.

The assert fires before any check on `request` type, so every Java
DAP attach config fails today unless callers pre-populate dummy
values for the five fields the early-return checks (`mainClass`,
`projectName`, `modulePaths`, `classPaths`, `javaExec`).

This PR adds an early return for `config.request == 'attach'`,
skipping the launch-specific enrichment (`build_workspace`,
`resolve_classpath`, `resolve_java_executable`) which are all
meaningless for an already-running JVM.

## Reproduction

Register a Java attach config in `dap.configurations.java`:

```lua
table.insert(dap.configurations.java, {
  type = 'java',
  request = 'attach',
  name = 'Java Attach :5005',
  hostName = '127.0.0.1',
  port = 5005,
})
```

Start a JDWP-listening JVM (e.g. `mvn spring-boot:run -Dspring-boot.run.jvmArguments='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'`), then `:DapContinue` and pick that config.

**Before this PR:**

```
To enrich the config, mainClass should already be present
.../nvim-java/lua/java-dap/setup.lua:54
```

**After this PR:** the attach proceeds, the DAP session initialises,
and breakpoints work as expected.

## Why the early-return location

The existing five-field early-return (lines 45-47) lets callers
satisfy the assert by passing dummy values. That works as a
workaround but is unintuitive — attach configs shouldn't have to
fake fields they semantically don't have. Adding the
`request == 'attach'` short-circuit ahead of it expresses the actual
invariant: attach configs need no enrichment, full stop.

## Test plan

- [x] Local install patched with the same change; `:DapContinue` →
  pick attach config → DAP session attaches, dap-ui opens, breakpoints
  fire on the running JVM.
- [x] Verified `request == 'launch'` configs still go through the
  full enrichment path (no regression — the early return only fires on
  `'attach'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)