### PR TITLE
Update JDTLS URL to use snapshot versions

### DIFF
--- a/lua/pkgm/specs/init.lua
+++ b/lua/pkgm/specs/init.lua
@@ -11,8 +11,8 @@ return {
 	JdtlsSpec({
 		name = 'jdtls',
 		version_range = { from = '1.43.0', to = '1.54.0' },
-		url = 'https://download.eclipse.org/{{name}}/milestones/'
-			.. '{{version}}/jdt-language-server-{{version}}-{{timestamp}}.tar.gz',
+		url = 'https://download.eclipse.org/jdtls/snapshots'
+			.. '/jdt-language-server-{{version}}-{{timestamp}}.tar.gz',
 	}),
 	BaseSpec({
 		name = 'java-test',


### PR DESCRIPTION
This pull request updates the download URL for the `jdtls` package in the `lua/pkgm/specs/init.lua` file to use the snapshots location instead of the milestones location.

- **Dependency source update:**
  * Changed the `url` for the `jdtls` package to point to `https://download.eclipse.org/jdtls/snapshots` instead of the milestones directory, ensuring the package fetches from the correct upstream location.