### PR TITLE
fix(dap): use vim.uv for TCP sockets

### DIFF
--- a/lua/java-dap/runner.lua
+++ b/lua/java-dap/runner.lua
@@ -41,12 +41,12 @@ end
 function Runner:before(conf, report)
 	log.debug('running "before" callback')
 
-	self.server = assert(vim.loop.new_tcp(), 'uv.new_tcp() must return handle')
+	self.server = assert(vim.uv.new_tcp(), 'uv.new_tcp() must return handle')
 	self.server:bind('127.0.0.1', 0)
 	self.server:listen(128, function(err)
 		assert(not err, err)
 
-		local sock = assert(vim.loop.new_tcp(), 'uv.new_tcp must return handle')
+		local sock = assert(vim.uv.new_tcp(), 'uv.new_tcp must return handle')
 		self.server:accept(sock)
 		local success = sock:read_start(report:get_stream_reader(sock))
 		assert(success == 0, 'failed to listen to reader')


### PR DESCRIPTION
## Summary

Create the DAP server and client sockets through `vim.uv`.

## Why

[The `vim.loop` alias is deprecated](https://neovim.io/doc/user/deprecated/#deprecated-0.10).

## What changed

- Replace both TCP constructors with `vim.uv.new_tcp()`.

## Testing

- `stylua --check lua/java-dap/runner.lua`
- `luacheck lua/java-dap/runner.lua`

## Related Issue(s)

None.
